### PR TITLE
feat: abstract file watching backend

### DIFF
--- a/src/backends/Backend.ts
+++ b/src/backends/Backend.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+/* eslint-disable @typescript-eslint/method-signature-style */
+
+import { type FileChangeEvent } from '../types';
+import { EventEmitter } from 'node:events';
+
+interface BackendEventEmitter {
+  on(event: 'ready', listener: () => void): this;
+  on(event: 'change', listener: ({ filename }: FileChangeEvent) => void): this;
+}
+
+export abstract class Backend
+  extends EventEmitter
+  implements BackendEventEmitter
+{
+  public constructor() {
+    super();
+  }
+
+  public abstract close(): Promise<void>;
+}

--- a/src/backends/Chokidar.ts
+++ b/src/backends/Chokidar.ts
@@ -1,0 +1,24 @@
+import { Backend } from './Backend';
+import * as chokidar from 'chokidar';
+
+export class Chokidar extends Backend {
+  private chokidar: chokidar.FSWatcher;
+
+  public constructor(project: string) {
+    super();
+
+    this.chokidar = chokidar.watch(project);
+
+    this.chokidar.on('ready', () => {
+      this.emit('ready');
+    });
+
+    this.chokidar.on('all', (event, filename) => {
+      this.emit('change', { filename });
+    });
+  }
+
+  public close() {
+    return this.chokidar.close();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,9 +140,8 @@ export type Configuration = {
   readonly triggers: readonly TriggerInput[];
 };
 
-export type ChokidarEvent = {
-  event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
-  path: string;
+export type FileChangeEvent = {
+  filename: string;
 };
 
 /**
@@ -160,7 +159,7 @@ export type Subscription = {
   expression: Expression;
   initialRun: boolean;
   teardown: () => Promise<void>;
-  trigger: (events: readonly ChokidarEvent[]) => Promise<void>;
+  trigger: (events: readonly FileChangeEvent[]) => Promise<void>;
 };
 
 export type TurbowatchController = {


### PR DESCRIPTION
Keep running into implementation-specific issues:

* Watchman is not tracking symbolic links (issue [#105](https://github.com/facebook/watchman/issues/105#issuecomment-1469496330))
* Chokidar is failing to detect file changes when multiple Chokidar processes are watching the same file (issue [#1240](https://github.com/paulmillr/chokidar/issues/1240))

Introducing this abstraction will help to switch between backends as needed.