### PR TITLE
fix: add linux fs.watch support

### DIFF
--- a/src/isFSWatcherAvailable.ts
+++ b/src/isFSWatcherAvailable.ts
@@ -7,6 +7,10 @@ const isMacOs = () => {
   return platform() === 'darwin';
 };
 
+const isLinux = () => {
+  return platform() === 'linux';
+};
+
 export const isFSWatcherAvailable = () => {
-  return semver.gte(process.version, '19.1.0') && isMacOs();
+  return semver.gte(process.version, '19.1.0') && (isMacOs() || isLinux());
 };


### PR DESCRIPTION
Based on `fs.watch` change log, it is supposed to be able to watch files recursively as of v19.1.0.