### PR TITLE
Add options to disable prefix and/or color on spawn output

### DIFF
--- a/src/createSpawn.ts
+++ b/src/createSpawn.ts
@@ -27,10 +27,14 @@ export const createSpawn = (
   {
     cwd = process.cwd(),
     abortSignal,
+    colorOutputPrefix = true,
+    prefixOutput = true,
     throttleOutput,
   }: {
     abortSignal?: AbortSignal;
+    colorOutputPrefix?: boolean;
     cwd?: string;
+    prefixOutput?: boolean;
     throttleOutput?: Throttle;
   } = {},
 ) => {
@@ -74,9 +78,20 @@ export const createSpawn = (
     let onStdout: (chunk: Buffer) => void;
     let onStderr: (chunk: Buffer) => void;
 
-    const formatChunk = (chunk: Buffer) => {
-      return prefixLines(chunk.toString().trimEnd(), colorText(taskId) + ' > ');
-    };
+    let formatChunk: (chunk: Buffer) => string;
+
+    if (prefixOutput) {
+      formatChunk = (chunk: Buffer) => {
+        return prefixLines(
+          chunk.toString().trimEnd(),
+          (colorOutputPrefix ? colorText(taskId) : taskId) + ' > ',
+        );
+      };
+    } else {
+      formatChunk = (chunk: Buffer) => {
+        return chunk.toString().trimEnd();
+      };
+    }
 
     if (throttleOutput?.delay) {
       onStdout = (chunk: Buffer) => {

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -160,7 +160,9 @@ export const subscribe = (trigger: Trigger): Subscription => {
           log,
           spawn: createSpawn(taskId, {
             abortSignal,
+            colorOutputPrefix: trigger.output?.colorPrefix,
             cwd: trigger.cwd,
+            prefixOutput: trigger.output?.prefix,
             throttleOutput: trigger.throttleOutput,
           }),
           taskId,
@@ -227,6 +229,8 @@ export const subscribe = (trigger: Trigger): Subscription => {
         try {
           await trigger.onTeardown({
             spawn: createSpawn(taskId, {
+              colorOutputPrefix: trigger.output?.colorPrefix,
+              prefixOutput: trigger.output?.prefix,
               throttleOutput: trigger.throttleOutput,
             }),
           });

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,11 @@ export type Throttle = {
   delay: number;
 };
 
+export type Output = {
+  colorPrefix?: boolean;
+  prefix?: boolean;
+};
+
 /**
  * @property expression watchman expression, e.g. https://facebook.github.io/watchman/docs/expr/allof.html
  * @property interruptible Sends abort signal to an ongoing routine, if any. Otherwise, waits for routine to finish. (default: true)
@@ -110,6 +115,7 @@ type TriggerInput = {
   name: string;
   onChange: OnChangeEventHandler;
   onTeardown?: OnTeardownEventHandler;
+  output?: Output;
   persistent?: boolean;
   retry?: Retry;
   throttleOutput?: Throttle;
@@ -125,6 +131,7 @@ export type Trigger = {
   name: string;
   onChange: OnChangeEventHandler;
   onTeardown?: OnTeardownEventHandler;
+  output?: Output;
   persistent: boolean;
   retry: Retry;
   throttleOutput: Throttle;

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -107,6 +107,7 @@ export const watch = (
         name: trigger.name,
         onChange: trigger.onChange,
         onTeardown: trigger.onTeardown,
+        output: trigger.output,
         persistent,
         retry: trigger.retry ?? {
           retries: 0,


### PR DESCRIPTION
I'm using turbowatch in an environment where I need more control over the output from the spawned process. The prefix and color is giving me some unnecessary additional work, so I added option to toggle those options. Hope this makes sense.