### PR TITLE
fix: use powershell if available on windows

### DIFF
--- a/src/createSpawn.ts
+++ b/src/createSpawn.ts
@@ -6,6 +6,7 @@ import { killPsTree } from './killPsTree';
 import { Logger } from './Logger';
 import { type Throttle } from './types';
 import chalk from 'chalk';
+import { execSync } from 'node:child_process';
 import randomColor from 'randomcolor';
 import { throttle } from 'throttle-debounce';
 import { $ } from 'zx';
@@ -22,6 +23,15 @@ const prefixLines = (subject: string, prefix: string): string => {
   }
 
   return response.join('\n');
+};
+
+const hasPowershell = () => {
+  try {
+    execSync('powershell.exe echo .');
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 export const createSpawn = (
@@ -71,7 +81,12 @@ export const createSpawn = (
 
     $.cwd = cwd;
 
-    $.prefix = `set -euo pipefail; export PATH="${binPath}:$PATH";`;
+    if (process.platform === 'win32' && hasPowershell()) {
+      $.shell = 'powershell.exe';
+      $.prefix = `$env:PATH+="${binPath}";`;
+    } else {
+      $.prefix = `set -euo pipefail; export PATH="${binPath}:$PATH";`;
+    }
 
     let onStdout: (chunk: Buffer) => void;
     let onStderr: (chunk: Buffer) => void;


### PR DESCRIPTION
With this modifcation, `createSpwan` will attempt to use `powershell.exe` on windows systems.
I tested this with powershell and git bash for windows, and both did work on my machine. I am open to any feedback on my approach as I am not sure it is ideal.
I hope you will still consider adding this as i would love to be able to use turbowatch on windows.

related issue: #40 